### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,14 @@ matrix:
   include:
     - php: 7.4
     - php: 7.3
+    - php: 7.2
     - php: nightly
   allow_failures:
-    - php: nightly 
+    - php: nightly
 
 before_script:
   - composer self-update
-  - travis_retry composer install --prefer-source --no-interaction --dev
+  - travis_retry composer install --prefer-dist --no-interaction
 script:
   - composer test
   - composer benchmark

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
       }
     },
     "scripts": {
-      "test": ["phpunit "],
+      "test": ["vendor/bin/phpunit --coverage-clover=coverage.xml"],
       "benchmark": ["php tests/Benchmark/run-benchmarks.php"]
     }
 }


### PR DESCRIPTION
# Changed log
- Using `"vendor/bin/phpunit --coverage-clover=coverage.xml"` to be `composer test` script.
- Add `php-7.2` version test on Travis CI build.
- Using the `--prefer-dist` to install stable dependencies on `composer install` command executing.
- Removing the `--dev` option during `composer install` command executing because it's deprecated option.

The deprecated warning message is as follows:

```
You are using the deprecated option "dev". Dev packages are installed by default now.
```